### PR TITLE
Add spring-boot-configuration-processor dependency

### DIFF
--- a/vertx-spring-boot-starter-http/pom.xml
+++ b/vertx-spring-boot-starter-http/pom.xml
@@ -45,6 +45,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/vertx-spring-boot-starter-mail/pom.xml
+++ b/vertx-spring-boot-starter-mail/pom.xml
@@ -31,6 +31,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
This dependency allows to generate metadata which help developers to
get better experience in their IDEs.