### PR TITLE
test: adapted actuator health expected response to include more information

### DIFF
--- a/vertx-spring-boot-starter-http/src/test/java/dev/snowdrop/vertx/http/it/HttpIT.java
+++ b/vertx-spring-boot-starter-http/src/test/java/dev/snowdrop/vertx/http/it/HttpIT.java
@@ -159,7 +159,7 @@ public class HttpIT extends TestBase {
             .uri("/actuator/health")
             .exchange()
             .expectBody(String.class)
-            .isEqualTo("{\"status\":\"UP\"}");
+            .value(org.hamcrest.Matchers.containsString("\"status\":\"UP\""));
     }
 
     @Test


### PR DESCRIPTION
The actuator health test was failing when executing on Jenkins with `Response body expected:<{"status":"UP"}> but was:<{"status":"UP","groups":["liveness","readiness"]}>`. 

This change adapts the test response to when more information is provided in this response.