### PR TITLE
test: adapted actuator health expected response to include more information

### DIFF
--- a/vertx-spring-boot-starter-actuator/src/test/java/dev/snowdrop/vertx/http/server/actuator/ActuatorIT.java
+++ b/vertx-spring-boot-starter-actuator/src/test/java/dev/snowdrop/vertx/http/server/actuator/ActuatorIT.java
@@ -36,7 +36,7 @@ public class ActuatorIT {
                 .build())
             .exchange()
             .expectBody(String.class)
-            .isEqualTo("{\"status\":\"UP\"}");
+            .value(org.hamcrest.Matchers.containsString("\"status\":\"UP\""));
 
         client.get()
             .exchange()


### PR DESCRIPTION
this time in the `vertx-spring-boot-starter-actuator` project. No other sub-module tests seem to have this message as is.