### PR TITLE
fix: manually performing the [...release...] prepare for next development iteration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>dev.snowdrop</groupId>
   <artifactId>vertx-spring-boot-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.1.4-SNAPSHOT</version>
+  <version>1.1.5-SNAPSHOT</version>
 
   <name>Vert.x Spring Boot - parent</name>
   <description>Spring Boot starters of different Vert.x components</description>

--- a/vertx-spring-boot-samples/pom.xml
+++ b/vertx-spring-boot-samples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-parent</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-samples</artifactId>

--- a/vertx-spring-boot-samples/vertx-spring-boot-sample-amqp-tls/pom.xml
+++ b/vertx-spring-boot-samples/vertx-spring-boot-sample-amqp-tls/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-samples</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-sample-amqp-tls</artifactId>

--- a/vertx-spring-boot-samples/vertx-spring-boot-sample-amqp/pom.xml
+++ b/vertx-spring-boot-samples/vertx-spring-boot-sample-amqp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-samples</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-sample-amqp</artifactId>

--- a/vertx-spring-boot-samples/vertx-spring-boot-sample-chunked/pom.xml
+++ b/vertx-spring-boot-samples/vertx-spring-boot-sample-chunked/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-samples</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-sample-chunked</artifactId>

--- a/vertx-spring-boot-samples/vertx-spring-boot-sample-http-oauth/pom.xml
+++ b/vertx-spring-boot-samples/vertx-spring-boot-sample-http-oauth/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-samples</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-sample-http-oauth</artifactId>

--- a/vertx-spring-boot-samples/vertx-spring-boot-sample-http-security/pom.xml
+++ b/vertx-spring-boot-samples/vertx-spring-boot-sample-http-security/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-samples</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-sample-http-security</artifactId>

--- a/vertx-spring-boot-samples/vertx-spring-boot-sample-http/pom.xml
+++ b/vertx-spring-boot-samples/vertx-spring-boot-sample-http/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-samples</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-sample-http</artifactId>

--- a/vertx-spring-boot-samples/vertx-spring-boot-sample-kafka/pom.xml
+++ b/vertx-spring-boot-samples/vertx-spring-boot-sample-kafka/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-samples</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-sample-kafka</artifactId>

--- a/vertx-spring-boot-samples/vertx-spring-boot-sample-mail/pom.xml
+++ b/vertx-spring-boot-samples/vertx-spring-boot-sample-mail/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-samples</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-sample-mail</artifactId>

--- a/vertx-spring-boot-samples/vertx-spring-boot-sample-sse/pom.xml
+++ b/vertx-spring-boot-samples/vertx-spring-boot-sample-sse/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-samples</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-sample-sse</artifactId>

--- a/vertx-spring-boot-samples/vertx-spring-boot-sample-websocket/pom.xml
+++ b/vertx-spring-boot-samples/vertx-spring-boot-sample-websocket/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-samples</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-sample-websocket</artifactId>

--- a/vertx-spring-boot-starter-actuator/pom.xml
+++ b/vertx-spring-boot-starter-actuator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-parent</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-starter-actuator</artifactId>

--- a/vertx-spring-boot-starter-amqp/pom.xml
+++ b/vertx-spring-boot-starter-amqp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-parent</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-starter-amqp</artifactId>

--- a/vertx-spring-boot-starter-http-test/pom.xml
+++ b/vertx-spring-boot-starter-http-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-parent</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-starter-http-test</artifactId>

--- a/vertx-spring-boot-starter-http/pom.xml
+++ b/vertx-spring-boot-starter-http/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-parent</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-starter-http</artifactId>

--- a/vertx-spring-boot-starter-kafka/pom.xml
+++ b/vertx-spring-boot-starter-kafka/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-parent</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-starter-kafka</artifactId>

--- a/vertx-spring-boot-starter-mail/pom.xml
+++ b/vertx-spring-boot-starter-mail/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-parent</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-starter-mail</artifactId>

--- a/vertx-spring-boot-starter/pom.xml
+++ b/vertx-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.snowdrop</groupId>
     <artifactId>vertx-spring-boot-parent</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vertx-spring-boot-starter</artifactId>


### PR DESCRIPTION
The Jenkins job didn't complete the 1.1.4 release correctly until the end, and missed pushing the changes to the development version.