### PR TITLE
chore: bumped Spring Boot version to 2.4.9 and Vert.x version to 3.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     <!-- Align with SmallRye Reactive Utils -->
     <mutiny-reactor.version>0.12.5</mutiny-reactor.version>
     <scala-library.version>2.13.2</scala-library.version>
-    <spring-boot.version>2.4.3</spring-boot.version>
-    <vertx.version>3.9.5</vertx.version>
+    <spring-boot.version>2.4.9</spring-boot.version>
+    <vertx.version>3.9.8</vertx.version>
     <!-- Align with Vert.x -->
     <vertx-mutiny-clients.version>1.3.0</vertx-mutiny-clients.version>
 


### PR DESCRIPTION
Vert.x version has been bumped because of an error produced by Netty

```
2021-08-31 15:32:26.715 ERROR 367895 --- [ntloop-thread-3] io.vertx.core.impl.ContextImpl           : Unhandled exception

java.lang.NullPointerException: cause
	at io.netty.util.internal.ObjectUtil.checkNotNull(ObjectUtil.java:39) ~[netty-common-4.1.66.Final.jar:4.1.66.Final]
```