### PR TITLE
test: adapted actuator health expected response 

### DIFF
--- a/vertx-spring-boot-starter-actuator/src/test/java/dev/snowdrop/vertx/http/server/actuator/ActuatorIT.java
+++ b/vertx-spring-boot-starter-actuator/src/test/java/dev/snowdrop/vertx/http/server/actuator/ActuatorIT.java
@@ -36,7 +36,7 @@ public class ActuatorIT {
                 .build())
             .exchange()
             .expectBody(String.class)
-            .isEqualTo("{\"status\":\"UP\"}");
+            .value(org.hamcrest.Matchers.containsString("\"status\":\"UP\""));
 
         client.get()
             .exchange()

--- a/vertx-spring-boot-starter-http/src/test/java/dev/snowdrop/vertx/http/it/HttpIT.java
+++ b/vertx-spring-boot-starter-http/src/test/java/dev/snowdrop/vertx/http/it/HttpIT.java
@@ -159,7 +159,7 @@ public class HttpIT extends TestBase {
             .uri("/actuator/health")
             .exchange()
             .expectBody(String.class)
-            .isEqualTo("{\"status\":\"UP\"}");
+            .value(org.hamcrest.Matchers.containsString("\"status\":\"UP\""));
     }
 
     @Test


### PR DESCRIPTION
to include incoming extra information.

```
[INFO] [ERROR]   Http2IT>HttpIT.shouldGetActuatorHealth:162 Response body expected:<{"status":"UP"}> but was:<{"status":"UP","groups":["liveness","readiness"]}>
[INFO] [ERROR]   HttpIT.shouldGetActuatorHealth:162 Response body expected:<{"status":"UP"}> but was:<{"status":"UP","groups":["liveness","readiness"]}>
```

Similar to #93  and #92 on branch `1.1.x`.