### PR TITLE
Execute blocking teardown code in vert.x worker pool

### DIFF
--- a/vertx-spring-boot-starter-kafka/src/test/java/dev/snowdrop/vertx/kafka/it/AbstractIT.java
+++ b/vertx-spring-boot-starter-kafka/src/test/java/dev/snowdrop/vertx/kafka/it/AbstractIT.java
@@ -12,6 +12,7 @@ import dev.snowdrop.vertx.kafka.KafkaProducer;
 import dev.snowdrop.vertx.kafka.KafkaProducerFactory;
 import dev.snowdrop.vertx.kafka.KafkaProperties;
 import dev.snowdrop.vertx.kafka.ProducerRecord;
+import io.vertx.core.Vertx;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import reactor.core.publisher.Mono;
 
@@ -37,12 +38,16 @@ public abstract class AbstractIT {
     }
 
     protected void tearDown() {
-        producersToCleanup.stream()
-            .map(KafkaProducer::close)
-            .forEach(Mono::block);
-        consumersToCleanup.stream()
-            .map(KafkaConsumer::close)
-            .forEach(Mono::block);
+        Vertx.vertx().executeBlocking(future -> {
+            producersToCleanup.stream()
+                .map(KafkaProducer::close)
+                .forEach(Mono::block);
+            consumersToCleanup.stream()
+                .map(KafkaConsumer::close)
+                .forEach(Mono::block);
+
+            future.complete();
+        });
     }
 
     protected <K, V> KafkaProducer<K, V> createProducer() {


### PR DESCRIPTION
Hi! :) 
Thanks for your effort for this handy project.

Your project does a great job ensuring the event loop remains non-blocking, indeed.
However  there is a tear down logic in AbstractIT that is blocking, as identified by BlockHound:
<img width="1090" alt="vs1-blocking" src="https://github.com/snowdrop/vertx-spring-boot/assets/56495631/f2231a97-854e-46f5-92a2-b0cdde830dc5">

This PR fixes the code to ensure the event loop remains reactive end to end. We re-ran the test cases and also analyzed the performance (CPU usage) before and after the fix:

**Before**
<img width="1411" alt="vs1-cpu-before" src="https://github.com/snowdrop/vertx-spring-boot/assets/56495631/9d42e812-0934-4550-b7d4-cda2c1ebf01d">

**After**
<img width="1444" alt="vs1-cpu-after" src="https://github.com/snowdrop/vertx-spring-boot/assets/56495631/a0a45d6b-a721-4c77-954b-9ab7afe7f064">
